### PR TITLE
changing waiting for Tx logic

### DIFF
--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -1,18 +1,27 @@
-import React from "react";
+import React from 'react'
+import { OverlayTrigger, Tooltip } from 'react-bootstrap'
 
 export default function Avatar({
   userLogin,
   className,
   src,
+  tooltip = false
 }: {
-  userLogin: string;
-  className?: string;
-  src?: string
+  userLogin: string
+  className?: string
+  src?: string;
+  tooltip?: boolean;
 }): JSX.Element {
   return (
-    <img
-      className={`avatar circle-3 ${className}`}
-      src={ src || `https://github.com/${userLogin}.png`}
-    />
-  );
+    <OverlayTrigger
+      key="right"
+      placement="right"
+      overlay={tooltip && <Tooltip id={`tooltip-right`}>@{userLogin}</Tooltip> || <></>}
+    >
+      <img
+        className={`avatar circle-3 ${className}`}
+        src={src || `https://github.com/${userLogin}.png`}
+      />
+    </OverlayTrigger>
+  )
 }

--- a/components/page-actions.tsx
+++ b/components/page-actions.tsx
@@ -245,6 +245,7 @@ export default function PageActions({
       <Button
         color="primary"
         onClick={handleStartWorking}
+        className="mr-1"
         disabled={isExecuting}
       >
         <span><Translation ns="bounty" label="actions.start-working.title" /></span>

--- a/components/proposal-progress.tsx
+++ b/components/proposal-progress.tsx
@@ -16,13 +16,15 @@ export default function ProposalProgress({ developers = [] }) {
                   className={`user-block-progress d-flex flex-column align-items-center`}
                   style={{ width: `${developer.percentage}%` }}
                 >
-                  <Avatar
-                    key={index}
-                    className="mb-2"
-                    userLogin={developer.githubLogin}
-                  />
+                    <Avatar
+                      key={index}
+                      className="mb-2"
+                      userLogin={developer.githubLogin}
+                      tooltip
+                      />
+                  
                   <p className="caption-small mb-0">
-                    {formatNumberToString(developer.percentage, 0)}% @{developer.githubLogin}
+                    {formatNumberToString(developer.percentage, 0)}%
                   </p>
                 </div>
               ))}

--- a/contexts/application.tsx
+++ b/contexts/application.tsx
@@ -133,8 +133,6 @@ export default function ApplicationContextProvider({children}) {
       if (!cheatAddress || !waitingForTx || !waitingForTx?.transactionHash) return
 
       web3.eth.getTransaction(waitingForTx.transactionHash).then(transaction => {  
-        console.log('[Transaction Found]', transaction)
-        
         dispatch(updateTransaction({
           ...waitingForTx,
           addressFrom: transaction.from,

--- a/contexts/application.tsx
+++ b/contexts/application.tsx
@@ -125,43 +125,31 @@ export default function ApplicationContextProvider({children}) {
     });
 
     if (txListener)
-      txListener.unsubscribe((err, success) => { console.log(`unsub`, err, success); });
+      clearInterval(txListener)
 
     const web3 = (window as any).web3;
 
-    setTxListener(web3.eth.subscribe(`pendingTransactions`, error => {error && console.log(error)})
-                      .on(`data`, (transactionHash) => {
-                        if (!cheatAddress || !waitingForTx)
-                          return;
+    const getPendingBlock = () => {
+      if (!cheatAddress || !waitingForTx || !waitingForTx?.transactionHash) return
 
-                        const getTx = (txHash) => web3.eth.getTransaction(transactionHash)
-                                                      .then(result => {
-                                                        if (!result)
-                                                          return getTx(transactionHash);
-                                                        return {
-                                                          ...waitingForTx,
-                                                          addressFrom: result.from,
-                                                          addressTo: result.to,
-                                                          transactionHash: result.transactionHash || transactionHash,
-                                                          blockHash: result.blockHash,
-                                                          confirmations: result?.nonce,
-                                                          status: TransactionStatus.pending,
-                                                        }
-                                                      })
-                                                      .catch((error) => {
-                                                        console.log(`Failed to getTransaction`, error);
-                                                      })
-                        getTx(transactionHash)
-                            .then(tx => {
-                              if (tx?.addressFrom === cheatAddress) {
-                                dispatch(updateTransaction(tx));
-                                waitingForTx = null;
-                              }
-                            })
-                            .catch(_ => {
-                              console.log(`Failed to subscribe to pastEvents`, _);
-                            });
-                      }))
+      web3.eth.getTransaction(waitingForTx.transactionHash).then(transaction => {  
+        console.log('[Transaction Found]', transaction)
+        
+        dispatch(updateTransaction({
+          ...waitingForTx,
+          addressFrom: transaction.from,
+          addressTo: transaction.to,
+          transactionHash: transaction.hash,
+          blockHash: transaction.blockHash,
+          confirmations: transaction?.nonce,
+          status: transaction.blockNumber ? TransactionStatus.completed : TransactionStatus.pending
+        }))
+  
+        if (transaction.blockNumber) waitingForTx = null
+      })
+    }
+
+    setTxListener(setInterval(getPendingBlock, 1000))
   }
 
   LoadApplicationReducers();
@@ -176,12 +164,17 @@ export default function ApplicationContextProvider({children}) {
   }, [authError])
 
   useEffect(() => {
-    if (waitingForTx)
-      return;
+    if (!waitingForTx)
+      waitingForTx = state.myTransactions.find(({status}) => status === TransactionStatus.pending) || null;
 
-    const pending = state.myTransactions.find(({status}) => status === 0);
-    if (pending)
-      waitingForTx = pending;
+    if(waitingForTx?.transactionHash) return
+
+    const transactionWithHash = state.myTransactions.find(({id}) => id === waitingForTx?.id);
+
+    if (!transactionWithHash || transactionWithHash?.status === TransactionStatus.failed)
+      waitingForTx = null
+    else
+      waitingForTx = transactionWithHash
 
   }, [state.myTransactions])
 

--- a/db/models/issue.model.js
+++ b/db/models/issue.model.js
@@ -35,7 +35,7 @@ class Issue extends Model {
     this.hasMany(models.pullRequest, {
       foreignKey: 'issueId',
       sourceKey: 'id',
-      as: 'pullrequests'
+      as: 'pullRequests'
     });
     this.hasMany(models.mergeProposal, {
       foreignKey: 'issueId',

--- a/db/models/issue.model.js
+++ b/db/models/issue.model.js
@@ -40,7 +40,7 @@ class Issue extends Model {
     this.hasMany(models.mergeProposal, {
       foreignKey: 'issueId',
       sourceKey: 'id',
-      as: 'merges'
+      as: 'mergeProposals'
     });
   }
 };

--- a/pages/account/my-pull-requests.tsx
+++ b/pages/account/my-pull-requests.tsx
@@ -14,6 +14,7 @@ import { changeLoadState } from '@contexts/reducers/change-load-state'
 import {GetServerSideProps} from 'next';
 import {getSession} from 'next-auth/react';
 import {serverSideTranslations} from 'next-i18next/serverSideTranslations';
+import { useTranslation } from 'next-i18next'
 
 export default function MyPullRequests() {
   const {
@@ -22,6 +23,7 @@ export default function MyPullRequests() {
   } = useContext(ApplicationContext)
 
   const [issues, setIssues] = useState([])
+  const { t } = useTranslation('pull-request')
   const { getIssuesOfUserPullRequests } = useMergeData()
 
   const page = usePage()
@@ -69,10 +71,10 @@ export default function MyPullRequests() {
           )}
           {issues?.length === 0 && !loading.isLoading ? (
             <div className="col-md-10 pt-3">
-              <NothingFound description={'No pull requests'}>
+              <NothingFound description={t('errors.not-found')}>
                 <InternalLink
                   href="/developers"
-                  label="Find an bounty to work on"
+                  label={String(t('find-a-bounty'))}
                   uppercase
                 />
               </NothingFound>

--- a/pages/api/issue/[...ids].ts
+++ b/pages/api/issue/[...ids].ts
@@ -10,7 +10,7 @@ async function get(req: NextApiRequest, res: NextApiResponse) {
 
   const include = [
     { association: 'developers' },
-    { association: 'pullrequests' },
+    { association: 'pullRequests' },
     { association: 'merges' }
   ]
 

--- a/pages/api/issue/[...ids].ts
+++ b/pages/api/issue/[...ids].ts
@@ -11,7 +11,7 @@ async function get(req: NextApiRequest, res: NextApiResponse) {
   const include = [
     { association: 'developers' },
     { association: 'pullRequests' },
-    { association: 'merges' }
+    { association: 'mergeProposals' }
   ]
 
   const issue = await models.issue.findOne({

--- a/pages/api/issues/index.ts
+++ b/pages/api/issues/index.ts
@@ -44,7 +44,7 @@ async function get(req: NextApiRequest, res: NextApiResponse) {
   const include = [
     { association: 'developers' },
     { association: 'pullRequests' },
-    { association: 'merges' }
+    { association: 'mergeProposals' }
   ]
   
   const issues = await models.issue.findAndCountAll(paginate({ where: whereCondition, include, nest: true }, req.query, [[req.query.sortBy || 'updatedAt', req.query.order || 'DESC']]));

--- a/pages/api/issues/index.ts
+++ b/pages/api/issues/index.ts
@@ -43,7 +43,7 @@ async function get(req: NextApiRequest, res: NextApiResponse) {
   }
   const include = [
     { association: 'developers' },
-    { association: 'pullrequests' },
+    { association: 'pullRequests' },
     { association: 'merges' }
   ]
   

--- a/pages/bounty.tsx
+++ b/pages/bounty.tsx
@@ -90,6 +90,8 @@ export default function PageIssue() {
 
         setIssue(issue);
 
+        console.log('issue', issue)
+
         if (!commentsIssue)
           getIssueComments(+issue.githubId, activeRepo.githubPath)
             .then((comments) => {

--- a/pages/bounty.tsx
+++ b/pages/bounty.tsx
@@ -90,8 +90,6 @@ export default function PageIssue() {
 
         setIssue(issue);
 
-        console.log('issue', issue)
-
         if (!commentsIssue)
           getIssueComments(+issue.githubId, activeRepo.githubPath)
             .then((comments) => {

--- a/public/locales/en/pull-request.json
+++ b/public/locales/en/pull-request.json
@@ -8,6 +8,7 @@
   "select": "Select a Pull Request",
   "review_one": "{{count}} review",
   "review_other": "{{count}} reviews",
+  "find-a-bounty": "Find a bounty to work on",
   "actions": {
     "create": {
       "title": "Create Pull Request",


### PR DESCRIPTION
There's no need to use network-tx-button component for the other contract interactions as they all use the BeproService.parseTransaction method, which returns the transaction's hash and thus it is possible to save it in the application context.