### PR TITLE
settings should account for process.env because _reasons_

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,68 @@ const publicRuntimeConfig = {
     api: process.env.NEXT_PUBLIC_API_HOST || "http://localhost:3000",
     home: process.env.NEXT_PUBLIC_HOME_URL || "http://localhost:3000",
     events: process.env.NEXT_PUBLIC_EVENTS_API || "http://localhost:3334",
+    ipfs: process.env.NEXT_PUBLIC_IPFS_BASE,
+    nft: process.env.NEXT_PUBLIC_NFT_URI,
+    web3Provider: process.env.NEXT_PUBLIC_WEB3_CONNECTION,
+    blockScan: process.env.NEXT_PUBLIC_BLOCKSCAN_LINK
+  },
+  contracts:{
+    settlerToken: process.env.NEXT_PUBLIC_SETTLER_ADDRESS,
+    network: process.env.NEXT_PUBLIC_CONTRACT_ADDRESS,
+    nftToken: process.env.NEXT_PUBLIC_NFT_ADDRESS,
+    networkRegistry: process.env.NEXT_PUBLIC_NETWORK_REGISTRY_ADDRESS,
+    transactionalToken: process.env.NEXT_PUBLIC_TRANSACTION_ADDRESS,
+  },
+  currency:{
+    defaultFiat: process.env.NEXT_PUBLIC_CURRENCY_MAIN,
+    api: process.env.NEXT_PUBLIC_CURRENCY_API,
+    defaultToken: process.env.NEXT_PUBLIC_CURRENCY_ID,
+    conversionList: process.env.NEXT_PUBLIC_CURRENCY_VSLIST,
+  },
+  defaultNetworkConfig: {
+    networkName: process.env.NEXT_PUBLIC_DEFAULT_NETWORK_NAME,
+    allowCustomTokens: process.env.NEXT_PUBLIC_ALLOW_CUSTOM_TOKENS,
+    adminWalletAddress: process.env.NEXT_PUBLIC_ADMIN_WALLET_ADDRESS,
+  },
+  nftUri: process.env.NEXT_PUBLIC_NFT_URI,
+  web3ProviderConnection: process.env.NEXT_PUBLIC_WEB3_CONNECTION,
+  github:{
+    botUser: process.env.NEXT_PUBLIC_GH_USER,
+  },
+  networkParametersLimits:{
+    disputableTime:{
+      min: process.env.NEXT_PUBLIC_DISPUTABLE_TIME_MIN,
+      max: eval(process.env.NEXT_PUBLIC_DISPUTABLE_TIME_MAX),
+    },
+    reedemTime:{
+      min: process.env.NEXT_PUBLIC_REDEEM_TIME_MIN,
+      max: eval(process.env.NEXT_PUBLIC_REDEEM_TIME_MAX),
+    },
+    councilAmount:{
+      min: process.env.NEXT_PUBLIC_COUNCIL_AMOUNT_MIN,
+      max: process.env.NEXT_PUBLIC_COUNCIL_AMOUNT_MAX,
+    },
+    disputesPercentage: process.env.NEXT_PUBLIC_DISPUTE_PERCENTAGE_MAX,
+
+  },
+  requiredChain: {
+    name: process.env.NEXT_PUBLIC_NEEDS_CHAIN_NAME,
+    id: process.env.NEXT_PUBLIC_NEEDS_CHAIN_ID,
+    token: process.env.NEXT_PUBLIC_NATIVE_TOKEN_NAME,
+  },
+  excludedJurisdictions: process.env.NEXT_PUBLIC_COUNTRY_CODE_BLOCKED,
+  chainIds: {
+    1: 'ethereum',
+    42: 'kovan',
+    3: 'ropsten',
+    4: 'rinkeby',
+    5: 'goerli',
+    1285: 'moonriver',
+    1337: 'localhost',
+    1500: 'seneca',
+    1501: 'afrodite',
+    1502: 'irene',
+    1503: 'iris'
   }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -70,7 +70,9 @@ const publicRuntimeConfig = {
     1500: 'seneca',
     1501: 'afrodite',
     1502: 'irene',
-    1503: 'iris'
+    1503: 'iris',
+    1504: 'diogenes',
+    1505: 'aurelius'
   }
 }
 

--- a/next.config.js
+++ b/next.config.js
@@ -32,8 +32,6 @@ const publicRuntimeConfig = {
     allowCustomTokens: process.env.NEXT_PUBLIC_ALLOW_CUSTOM_TOKENS,
     adminWalletAddress: process.env.NEXT_PUBLIC_ADMIN_WALLET_ADDRESS,
   },
-  nftUri: process.env.NEXT_PUBLIC_NFT_URI,
-  web3ProviderConnection: process.env.NEXT_PUBLIC_WEB3_CONNECTION,
   github:{
     botUser: process.env.NEXT_PUBLIC_GH_USER,
   },

--- a/scripts/settings/save-from-env.js
+++ b/scripts/settings/save-from-env.js
@@ -17,6 +17,7 @@ const publicSettings = [
   PublicSettingItem("ipfs", process.env.NEXT_PUBLIC_IPFS_BASE, "string", "urls"),
   PublicSettingItem("blockScan", process.env.NEXT_PUBLIC_BLOCKSCAN_LINK || '', "string", "urls"),
   PublicSettingItem("web3Provider", process.env.NEXT_PUBLIC_WEB3_CONNECTION, "string", "urls"),
+  PublicSettingItem("nft", process.env.NEXT_PUBLIC_NFT_URI, "string", "urls"),
   PublicSettingItem("settlerToken", process.env.NEXT_PUBLIC_SETTLER_ADDRESS, "string", "contracts"),
   PublicSettingItem("network", process.env.NEXT_PUBLIC_CONTRACT_ADDRESS, "string", "contracts"),
   PublicSettingItem("transactionalToken", process.env.NEXT_PUBLIC_TRANSACTION_ADDRESS, "string", "contracts"),

--- a/services/dao-service.ts
+++ b/services/dao-service.ts
@@ -490,8 +490,8 @@ export default class DAO {
     return this.network.disputeBountyProposal(bountyId, proposalId);
   }
 
-  async closeBounty(bountyId: number, proposalId: number): Promise<TransactionReceipt> {
-    return this.network.closeBounty(bountyId, proposalId);
+  async closeBounty(bountyId: number, proposalId: number, uri): Promise<TransactionReceipt> {
+    return this.network.closeBounty(bountyId, proposalId, uri);
   }
 
   async updateBountyAmount(bountyId: number, amount: number): Promise<TransactionReceipt> {

--- a/x-hooks/use-api.tsx
+++ b/x-hooks/use-api.tsx
@@ -23,6 +23,7 @@ import { Token } from "interfaces/token";
 import { api, eventsApi } from "services/api";
 
 import { Entities, Events } from "types/dappkit";
+import getConfig from "next/config";
 interface NewIssueParams {
   title: string;
   description: string;
@@ -44,6 +45,8 @@ type FileUploadReturn = {
   fileName: string;
   size: string;
 }[]
+
+const { publicRuntimeConfig } = getConfig();
 
 const repoList: ReposList = [];
 
@@ -493,7 +496,12 @@ export default function useApi() {
 
   async function getSettings() {
     return api.get("/settings")
-      .then((({ data }) => data))
+      .then((({ data }) => {
+        return {
+          ...publicRuntimeConfig,
+          ...data
+        }
+      }))
       .catch((error) => { throw error });
   }
 

--- a/x-hooks/use-bepro.tsx
+++ b/x-hooks/use-bepro.tsx
@@ -22,6 +22,7 @@ import { NetworkParameters } from "types/dappkit";
 
 import useApi from "x-hooks/use-api";
 import useTransactions from "x-hooks/useTransactions";
+import {useSettings} from "../contexts/settings";
 
 
 export default function useBepro() {
@@ -30,6 +31,7 @@ export default function useBepro() {
   const { networkIssue, activeIssue, updateIssue } = useIssue();
   const { service: DAOService } = useDAO();
   const { t } = useTranslation("common");
+  const { settings: {urls: {nft: uri}} } = useSettings();
 
   const { processEvent } = useApi();
   const txWindow = useTransactions();
@@ -99,7 +101,7 @@ export default function useBepro() {
                                           activeNetwork);
       dispatch(closeIssueTx);
 
-      await DAOService.closeBounty(+bountyId, +proposalscMergeId)
+      await DAOService.closeBounty(+bountyId, +proposalscMergeId, uri)
         .then((txInfo: Error | TransactionReceipt | PromiseLike<Error | TransactionReceipt>) => {
           txWindow.updateItem(closeIssueTx.payload.id,
                               parseTransaction(txInfo, closeIssueTx.payload));

--- a/x-hooks/use-bepro.tsx
+++ b/x-hooks/use-bepro.tsx
@@ -31,7 +31,7 @@ export default function useBepro() {
   const { networkIssue, activeIssue, updateIssue } = useIssue();
   const { service: DAOService } = useDAO();
   const { t } = useTranslation("common");
-  const { settings: {urls: {nft: uri}} } = useSettings();
+  const { settings } = useSettings();
 
   const { processEvent } = useApi();
   const txWindow = useTransactions();
@@ -101,7 +101,7 @@ export default function useBepro() {
                                           activeNetwork);
       dispatch(closeIssueTx);
 
-      await DAOService.closeBounty(+bountyId, +proposalscMergeId, uri)
+      await DAOService.closeBounty(+bountyId, +proposalscMergeId, settings?.urls?.nft)
         .then((txInfo: Error | TransactionReceipt | PromiseLike<Error | TransactionReceipt>) => {
           txWindow.updateItem(closeIssueTx.payload.id,
                               parseTransaction(txInfo, closeIssueTx.payload));


### PR DESCRIPTION
The publicRuntimeConfig should
1. match the new settings
2. be intertwined with the settings
3. but overwritten if database settings exist

---

To achieve this, these changes were made

- add publicRuntimeConfig to settings
- add uri to closeBounty
- recreate public runtime config

effectively, if we save our public settings to the database nothing alters, otherwise it will use the (public) values we have in our `.env`

---

This branch is a in-between and should be only merged on 2.1 when we remove the settings database from existance. This was a messed up idea, and we have to revert it. my bad.