### PR TITLE
fix root redirect to use environment variable

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,8 @@ const publicRuntimeConfig = {
     home: process.env.NEXT_PUBLIC_HOME_URL || "http://localhost:3000",
     events: process.env.NEXT_PUBLIC_EVENTS_API || "http://localhost:3334",
     ipfs: process.env.NEXT_PUBLIC_IPFS_BASE
-  }
+  },
+  defaultName: process.env.NEXT_PUBLIC_DEFAULT_NETWORK_NAME
 }
 
 // Will only be available on the server-side
@@ -63,7 +64,7 @@ module.exports = () => {
       return [
         {
           source: "/",
-          destination: "/bepro",
+          destination: `/${publicRuntimeConfig.defaultName}`,
           permanent: true
         }
       ];


### PR DESCRIPTION
redirect to NEXT_PUBLIC_DEFAULT_NETWORK_NAME instead of hard-coded "bepro"