### PR TITLE
Bepro 1465 explore icon not aligned with rest of nav

### DIFF
--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -80,13 +80,13 @@ export default function MainNav() {
   function LinkExplore() {
     return (
       <InternalLink
-        className="mt-1"
+        className="mgt-3"
         href={"/explore"}
         blank={!noNeedNetworkInstance}
         label={<Translation label={"main-nav.explorer"} />}
         nav
         uppercase
-        icon={!noNeedNetworkInstance ? <ExternalLinkIcon className="mb-1" width={12} height={12} />:null}
+        icon={!noNeedNetworkInstance ? <ExternalLinkIcon className="ms-1 mb-1 pt-1" width='12' height='12' />:null}
       />
     );
   }

--- a/styles/styles.scss
+++ b/styles/styles.scss
@@ -86,6 +86,10 @@ li {
   margin-top: 20px !important;
 }
 
+.mgt-3 {
+  margin-top: 3px !important;
+}
+
 .mgb-20 {
   margin-bottom: 50px !important;
 }


### PR DESCRIPTION
Old:
![image](https://user-images.githubusercontent.com/34746557/223537314-0b586643-7638-48a9-8149-3a1dbaa88bfd.png)


New:
![image](https://user-images.githubusercontent.com/34746557/223537138-2192db76-cea6-4725-b6cf-4938a251ecfc.png)
